### PR TITLE
Update ThermiaOnlineAPI version to ThermiaOnlineAPI==5.0.0

### DIFF
--- a/custom_components/thermia/manifest.json
+++ b/custom_components/thermia/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/klejejs/ha-thermia-heat-pump-integration/issues",
   "requirements": [
-    "ThermiaOnlineAPI==4.3.0"
+    "ThermiaOnlineAPI==5.0.0"
   ],
   "version": "1.0"
 }


### PR DESCRIPTION
This PR updates the ThermiaOnlineAPI version to the latest version which is ThermiaOnlineAPI==5.0.0.