### PR TITLE
Remove Genesis API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Platform | Description
 
 To set up Thermia Heat Pump Integration, go to Settings -> Integrations -> Add Integration and search for Thermia Heat Pump.
 
-Depending on the url you use to see your heat pump online, you need to choose the following API type:
-* `classic` - for url: https://online.thermia.se
-* `genesis` - for url: https://online-genesis.thermia.se
-
 ## Installation
 
 Open HACS, go to the Integrations view and search for Thermia Heat Pump Integration.

--- a/custom_components/thermia/__init__.py
+++ b/custom_components/thermia/__init__.py
@@ -1,4 +1,5 @@
 """Thermia heat pump integration."""
+
 from __future__ import annotations
 
 import asyncio
@@ -11,9 +12,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from ThermiaOnlineAPI import Thermia
-from ThermiaOnlineAPI.api.ThermiaAPI import ThermiaAPI
 
-from .const import API_TYPE, API_TYPE_CLASSIC, CONF_PASSWORD, CONF_USERNAME, DOMAIN
+from .const import CONF_PASSWORD, CONF_USERNAME, DOMAIN
 
 PLATFORMS: list[str] = ["binary_sensor", "sensor", "switch", "water_heater"]
 
@@ -33,11 +33,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     username = config_entry.data[CONF_USERNAME]
     password = config_entry.data[CONF_PASSWORD]
-    api_type = config_entry.data.get(API_TYPE, API_TYPE_CLASSIC)
 
-    thermia = await hass.async_add_executor_job(
-        lambda: Thermia(username, password, api_type)
-    )
+    thermia = await hass.async_add_executor_job(lambda: Thermia(username, password))
 
     coordinator = ThermiaDataUpdateCoordinator(hass, thermia)
 

--- a/custom_components/thermia/config_flow.py
+++ b/custom_components/thermia/config_flow.py
@@ -1,4 +1,5 @@
 """Config Flow for Thermia."""
+
 import logging
 
 import voluptuous as vol
@@ -8,9 +9,6 @@ from homeassistant import config_entries
 from ThermiaOnlineAPI import AuthenticationException, Thermia
 
 from .const import (
-    API_TYPE,
-    API_TYPE_CLASSIC,
-    API_TYPES,
     CONF_PASSWORD,
     CONF_USERNAME,
     DOMAIN,
@@ -20,7 +18,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(API_TYPE, default=API_TYPE_CLASSIC): vol.In(API_TYPES),
     }
 )
 
@@ -44,7 +41,6 @@ class ThermiaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 lambda: Thermia(
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
-                    user_input[API_TYPE],
                 )
             )
             await self.hass.async_add_executor_job(thermia.fetch_heat_pumps)

--- a/custom_components/thermia/const.py
+++ b/custom_components/thermia/const.py
@@ -3,12 +3,6 @@ DOMAIN = "thermia"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 
-API_TYPE_CLASSIC = "classic"
-API_TYPE_GENESIS = "genesis"
-
-API_TYPE = "api_type"
-API_TYPES = [API_TYPE_CLASSIC, API_TYPE_GENESIS]
-
 MDI_INFORMATION_OUTLINE_ICON = "mdi:information-outline"
 MDI_TIMER_COG_OUTLINE_ICON = "mdi:timer-cog-outline"
 MDI_TEMPERATURE_ICON = "mdi:thermometer"

--- a/custom_components/thermia/translations/en.json
+++ b/custom_components/thermia/translations/en.json
@@ -6,8 +6,7 @@
         "description": "Set up Thermia Heat Pump integration",
         "data": {
           "username": "Thermia Username",
-          "password": "Thermia Password",
-          "api_type": "API type (check readme for more info):"
+          "password": "Thermia Password"
         }
       }
     },

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -6,13 +6,15 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "python.pythonPath": "/usr/local/bin/python"
+        "python.pythonPath": "/usr/local/bin/python",
+        "python.formatting.provider": "black"
       },
       "extensions": [
         "GitHub.copilot",
         "github.vscode-pull-request-github",
         "ms-python.python",
-        "ms-python.vscode-pylance"
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter"
       ]
     }
   }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,5 +15,5 @@ install_packages() {
 }
 
 install_packages "pip<23.2,>=21.3.1"
-install_packages setuptools wheel
+install_packages setuptools wheel black
 install_packages -r requirements.txt


### PR DESCRIPTION
As Thermia has removed its separate Genesis API and migrated it under the previously considered classic API, the API config is removed from integration.