### PR TITLE
Refactor operational statuses and add power statuses

### DIFF
--- a/custom_components/thermia/binary_sensor.py
+++ b/custom_components/thermia/binary_sensor.py
@@ -1,14 +1,16 @@
 """Thermia binary sensor integration."""
 
 from __future__ import annotations
+from typing import List
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from .binary_sensors.operational_status_binary_sensor import (
-    ThermiaOperationalStatusBinarySensor,
+from .binary_sensors.operational_or_power_status_binary_sensor import (
+    ThermiaOperationalOrPowerStatusBinarySensor,
 )
+from ThermiaOnlineAPI import ThermiaHeatPump
 
 from .const import (
     DOMAIN,
@@ -27,83 +29,39 @@ async def async_setup_entry(
 
     hass_thermia_binary_sensors = []
 
-    for idx, heat_pump in enumerate(coordinator.data.heat_pumps):
-        if heat_pump.operational_status_compressor_status is not None:
-            hass_thermia_binary_sensors.append(
-                ThermiaOperationalStatusBinarySensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Compressor Status",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    BinarySensorDeviceClass.RUNNING,
-                    "operational_status_compressor_status",
-                )
-            )
+    heat_pumps: List[ThermiaHeatPump] = coordinator.data.heat_pumps
 
-        if heat_pump.operational_status_brine_pump_status is not None:
-            hass_thermia_binary_sensors.append(
-                ThermiaOperationalStatusBinarySensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Brine Pump Status",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    BinarySensorDeviceClass.RUNNING,
-                    "operational_status_brine_pump_status",
+    for idx, heat_pump in enumerate(heat_pumps):
+        if heat_pump.available_operational_statuses is not None and heat_pump.running_operational_statuses is not None:
+            for operational_status in heat_pump.available_operational_statuses:
+                name = operational_status.replace("_", " ").title()
+                hass_thermia_binary_sensors.append(
+                    ThermiaOperationalOrPowerStatusBinarySensor(
+                        coordinator,
+                        idx,
+                        "is_online",
+                        f"{name} Operational Status",
+                        MDI_INFORMATION_OUTLINE_ICON,
+                        BinarySensorDeviceClass.RUNNING,
+                        operational_status,
+                        "running_operational_statuses"
+                    )
                 )
-            )
 
-        if heat_pump.operational_status_radiator_pump_status is not None:
-            hass_thermia_binary_sensors.append(
-                ThermiaOperationalStatusBinarySensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Radiator Pump Status",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    BinarySensorDeviceClass.RUNNING,
-                    "operational_status_radiator_pump_status",
+        if heat_pump.available_power_statuses is not None and heat_pump.running_power_statuses is not None:
+            for power_status in heat_pump.available_power_statuses:
+                name = power_status.replace("_", " ").title()
+                hass_thermia_binary_sensors.append(
+                    ThermiaOperationalOrPowerStatusBinarySensor(
+                        coordinator,
+                        idx,
+                        "is_online",
+                        f"{name} Power Status",
+                        MDI_INFORMATION_OUTLINE_ICON,
+                        BinarySensorDeviceClass.RUNNING,
+                        power_status,
+                        "running_power_statuses"
+                    )
                 )
-            )
-
-        if heat_pump.operational_status_cooling_status is not None:
-            hass_thermia_binary_sensors.append(
-                ThermiaOperationalStatusBinarySensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Cooling Status",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    BinarySensorDeviceClass.RUNNING,
-                    "operational_status_cooling_status",
-                )
-            )
-
-        if heat_pump.operational_status_hot_water_status is not None:
-            hass_thermia_binary_sensors.append(
-                ThermiaOperationalStatusBinarySensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Hot Water Status",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    BinarySensorDeviceClass.RUNNING,
-                    "operational_status_hot_water_status",
-                )
-            )
-
-        if heat_pump.operational_status_heating_status is not None:
-            hass_thermia_binary_sensors.append(
-                ThermiaOperationalStatusBinarySensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Heating Status",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    BinarySensorDeviceClass.RUNNING,
-                    "operational_status_heating_status",
-                )
-            )
 
     async_add_entities(hass_thermia_binary_sensors)

--- a/custom_components/thermia/binary_sensors/operational_or_power_status_binary_sensor.py
+++ b/custom_components/thermia/binary_sensors/operational_or_power_status_binary_sensor.py
@@ -8,8 +8,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from ..const import DOMAIN
 
 
-class ThermiaOperationalStatusBinarySensor(CoordinatorEntity, BinarySensorEntity):
-    """Representation of an Thermia Operational Status binary sensor."""
+class ThermiaOperationalOrPowerStatusBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Representation of an Thermia Operational or Power Status binary sensor."""
 
     def __init__(
         self,
@@ -19,7 +19,8 @@ class ThermiaOperationalStatusBinarySensor(CoordinatorEntity, BinarySensorEntity
         binary_sensor_name,
         mdi_icon,
         device_class,
-        value_prop,
+        status_value,
+        running_status_list,
     ):
         super().__init__(coordinator)
         self.idx = idx
@@ -28,7 +29,8 @@ class ThermiaOperationalStatusBinarySensor(CoordinatorEntity, BinarySensorEntity
         self._binary_sensor_name = binary_sensor_name
         self._mdi_icon = mdi_icon
         self._device_class = device_class
-        self._value_prop = value_prop
+        self._status_value = status_value
+        self._running_status_list = running_status_list
 
     @property
     def available(self):
@@ -71,4 +73,4 @@ class ThermiaOperationalStatusBinarySensor(CoordinatorEntity, BinarySensorEntity
         """Return the state of the sensor."""
         heat_pump = self.coordinator.data.heat_pumps[self.idx]
 
-        return getattr(heat_pump, self._value_prop)
+        return self._status_value in getattr(heat_pump, self._running_status_list)

--- a/custom_components/thermia/sensor.py
+++ b/custom_components/thermia/sensor.py
@@ -256,86 +256,6 @@ async def async_setup_entry(
         # Operational status data
         ###########################################################################
 
-        if heat_pump.operational_status_auxiliary_heater_3kw is not None:
-            hass_thermia_sensors.append(
-                ThermiaGenericSensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Auxiliary Heater 3KW",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    EntityCategory.DIAGNOSTIC,
-                    None,
-                    "measurement",
-                    "operational_status_auxiliary_heater_3kw",
-                    None,
-                )
-            )
-
-        if heat_pump.operational_status_auxiliary_heater_6kw is not None:
-            hass_thermia_sensors.append(
-                ThermiaGenericSensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Auxiliary Heater 6KW",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    EntityCategory.DIAGNOSTIC,
-                    None,
-                    "measurement",
-                    "operational_status_auxiliary_heater_6kw",
-                    None,
-                )
-            )
-
-        if heat_pump.operational_status_auxiliary_heater_9kw is not None:
-            hass_thermia_sensors.append(
-                ThermiaGenericSensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Auxiliary Heater 9KW",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    EntityCategory.DIAGNOSTIC,
-                    None,
-                    "measurement",
-                    "operational_status_auxiliary_heater_9kw",
-                    None,
-                )
-            )
-
-        if heat_pump.operational_status_auxiliary_heater_12kw is not None:
-            hass_thermia_sensors.append(
-                ThermiaGenericSensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Auxiliary Heater 12KW",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    EntityCategory.DIAGNOSTIC,
-                    None,
-                    "measurement",
-                    "operational_status_auxiliary_heater_12kw",
-                    None,
-                )
-            )
-
-        if heat_pump.operational_status_auxiliary_heater_15kw is not None:
-            hass_thermia_sensors.append(
-                ThermiaGenericSensor(
-                    coordinator,
-                    idx,
-                    "is_online",
-                    "Auxiliary Heater 15KW",
-                    MDI_INFORMATION_OUTLINE_ICON,
-                    EntityCategory.DIAGNOSTIC,
-                    None,
-                    "measurement",
-                    "operational_status_auxiliary_heater_15kw",
-                    None,
-                )
-            )
-
         if heat_pump.operational_status_integral is not None:
             hass_thermia_sensors.append(
                 ThermiaGenericSensor(
@@ -457,4 +377,7 @@ async def async_setup_entry(
         for idx, _ in enumerate(coordinator.data.heat_pumps)
     ]
 
-    async_add_entities([*hass_thermia_active_alarms_sensors, *hass_thermia_sensors])
+    async_add_entities([
+        *hass_thermia_active_alarms_sensors,
+        *hass_thermia_sensors
+    ])


### PR DESCRIPTION
Breaking changes:
* The operational status code is refactored to show all available operational statuses instead of predefined ones; thus, the existing operational status entity names and IDs will change. This can impact any scripts or automations that include operational statuses or Lovelace dashboards that display them. This change will also make some existing entities unavailable, as they are replaced, those unavailable entities can safely be deleted.
* Incorrect Auxiliary heater sensors have been removed in favor of new "Power Status" entities that will display whether any of the auxiliary heaters are running. 