### PR TITLE
Update ThermiaOnlineAPI version to 6.2.0

### DIFF
--- a/custom_components/thermia/manifest.json
+++ b/custom_components/thermia/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/klejejs/ha-thermia-heat-pump-integration/issues",
   "requirements": [
-    "ThermiaOnlineAPI==6.1.0"
+    "ThermiaOnlineAPI==6.2.0"
   ],
   "version": "1.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 homeassistant==2024.4.1
-ThermiaOnlineAPI==6.1.0
+ThermiaOnlineAPI==6.2.0


### PR DESCRIPTION
This PR updates the ThermiaOnlineAPI version to the latest version which is 6.2.0.